### PR TITLE
Added systems updates as first provision task in vagrant boxes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vbox.customize ["modifyvm", :id, "--cpus", "2"]
     end
 
+    c.vm.provision :shell, path: "deploy/vagrant.sh", args: "system_updates"
     c.vm.provision :shell, path: "deploy/vagrant.sh", args: "install_dev_requirements"
     c.vm.provision :shell, path: "deploy/vagrant.sh", args: "install_elasticsearch"
     c.vm.provision :shell, path: "deploy/vagrant.sh", args: "install_mysql"
@@ -38,6 +39,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vbox.customize ["modifyvm", :id, "--cpus", "2"]
     end
 
+    c.vm.provision :shell, path: "deploy/vagrant.sh", args: "system_updates"
     c.vm.provision :shell, path: "deploy/vagrant.sh", args: "install_prod_requirements"
     c.vm.provision :shell, path: "deploy/vagrant.sh", args: "install_elasticsearch"
     c.vm.provision :shell, path: "deploy/vagrant.sh", args: "install_mysql"


### PR DESCRIPTION
I've found an issue creating the vagrant machine due apt-get index wasn't up to date as it comes from vagrant base box.

For this reason I think that it's better to run as a first provision script for any vagrant machine the `system_updates` which exists in `deploy/vagrant.sh` .