### PR TITLE
Set to private network type to use NFS sync folder on OSX

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     if RUBY_PLATFORM.match(/darwin/)
       config.vm.synced_folder ".", "/vagrant", type: "nfs"
+      config.vm.network "private_network", type: "dhcp"
     end
     c.vm.network :forwarded_port, host: 3000, guest: 3000
     c.vm.provider "virtualbox" do |vbox|


### PR DESCRIPTION
NFS sync mechanism doesn't work with "host-only" network adapter type, so I forced to use private network on OSX vagrant configuration.

